### PR TITLE
HOT FIX FOR IMPORTING PROJECTS.

### DIFF
--- a/SCATT/.classpath
+++ b/SCATT/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/SCATT/.gitignore
+++ b/SCATT/.gitignore
@@ -1,7 +1,7 @@
 /bin/
 
 #ignore a lot of local IDE settings - used stars in case repo's name changes.
-/.project
-/.classpath
+#/.project
+#/.classpath
 /.settings/*
 /.checkstyle

--- a/SCATT/.project
+++ b/SCATT/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>SCATT</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
I thought we had all got eclipse set up with the git project? But since there has been so much issue I decided to try and import the project using a javascript eclipse IDE to emulate having a different version.

I had similar issues to chad and broderick, but I found a way to get them working without hacking the project name to src. 

It is rather simple, I just changed the .gitignore to not block the .classpath and the .project file and I added those two files to the repo. Initially I didn't want everyone's person IDE settings to conflict, but it appears that those settings are in the .settings folder, so we should be safe. 

-----------------------------------------------------------------------------------------------------------

It was my bad, I assumed we didn't need the .project file. But when I asked if it worked it appeared that people had gotten git set up on their desktops. 

-----------------------------------------------------------------------------------------------------------
Instructions to test if this works:

1. clone the repo to your local repositories (I'm pretty sure everyone has already done this). 
2. import git project (stay with me, there is a new option).
3. select "import existing Eclipse projects"
4. select the SCATT folder (this previously would not show anything to select); select top folder - not src subfolder.
5. DONE - this should work. HOWEVER if you change to a branch that doesn't have the patch yet, the project will be empty until you change back to a branch with the patch. I think we need to do a pull this into the master asap, but I need you guys to test if you can import this branch as a project first. 
-------------------------------------------------------------------------------------------------------------
